### PR TITLE
Restrict CSS files to stylesheets only

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -36,7 +36,7 @@ class Document
     public function getCssFiles(UriInterface $originUrl = null)
     {
         if (!$this->cssFiles) {
-            $this->cssFiles = $this->getUrls("//link", "href", $originUrl);
+            $this->cssFiles = $this->getUrls("//link[@rel='stylesheet']", "href", $originUrl);
         }
         return $this->cssFiles;
     }

--- a/test/unit/DocumentTest.php
+++ b/test/unit/DocumentTest.php
@@ -73,4 +73,24 @@ class DocumentTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($currentUrls, $expectedUrls);
     }
 
+    public function testGetCssFiles()
+    {
+        $document = new Document(file_get_contents(__DIR__ . '/fixtures/referencedUrls.html'));
+
+        $urls = $document->getCssFiles(new Uri('http://www.example.com/test/'));
+
+        foreach ($urls as $url) {
+            $currentUrls[] = (string) $url;
+        }
+
+        $expectedUrls = array(
+            'http://fonts.googleapis.com/css?family=Dancing+Script'
+        );
+
+        sort($expectedUrls);
+        sort($currentUrls);
+
+        $this->assertEquals($currentUrls, $expectedUrls);
+    }
+
 }

--- a/test/unit/fixtures/referencedUrls.html
+++ b/test/unit/fixtures/referencedUrls.html
@@ -4,10 +4,14 @@
     <meta charset="UTF-8">
     <title></title>
 
+    <link rel="canonical" href="http://www.example.com">
+
     <script src="//foreign-domain-schema-relative.com/file.js"></script>
     <script src="//foreign-domain-schema-relative.com"></script>
 
     <link href='http://fonts.googleapis.com/css?family=Dancing+Script' rel='stylesheet' type='text/css'>
+
+    <link rel="dns-prefetch" href="http://www.example.com/nested-page.html">
 
 </head>
 <body>


### PR DESCRIPTION
When analysing our website with [Smoke](https://github.com/phmLabs/Smoke) I saw some false positives regarding (the number of) CSS files on the page:

``` bash
Smoke.phar analyse "http://www.trivago.de" -u 1
```

returned

```
Failed tests:

    http://www.trivago.de  coming from
    - Too many (15) css files were found. [rule: _HtmlCssCount]
    - [...]
```

Although there are only **three** CSS files / stylesheets in the initial payload. This is due to `\whm\Html\Document::getCssFiles` selecting only with xpath `//link` which also catches canonical tags, dns-prefetch links and others.

This pull request adds a restriction to stylesheets only by using `//link[@rel='stylesheet']`.
Test cases provided accordingly
