### PR TITLE
Trim spaces in href. Url decode Uri before parsing

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -94,6 +94,7 @@ class Uri implements UriInterface
         }
 
         if (!empty($uri)) {
+            $uri = urldecode(trim($uri));
             $this->parseUri($uri);
         }
     }


### PR DESCRIPTION
- parse special URLs which do something like "http&#058;//..."
- parse URIs in href with preciding/leading spaces
